### PR TITLE
Added in support for preferRoot

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,19 @@ const {app} = require('electron');
 const {moveToApplications} = require('electron-lets-move');
 
 app.on('ready', function() {
-  moveToApplications(function(err, moved) {
-    if (err) {
-      // log error, something went wrong whilst moving the app.
-    }
-    if (!moved) {
-      // the user asked not to move the app, it's up to the parent application
-      // to store this information and not hassle them again.
-    }
+  moveToApplications({
+    preferRoot: true|false,
+    callback: (err, moved) => {
+      if (err) {
+        // log error, something went wrong whilst moving the app.
+      }
+      if (!moved) {
+        // the user asked not to move the app, it's up to the parent application
+        // to store this information and not hassle them again.
+      }
 
-    // do the rest of your application startup
+      // do the rest of your application startup
+    }  
   });
 });
 ```
@@ -55,7 +58,8 @@ import {moveToApplications} from 'electron-lets-move';
 
 app.on('ready', async () => {
   try {
-    const moved = await moveToApplications();
+    const opts = {};    
+    const moved = await moveToApplications(opts);
     if (!moved) {
       // the user asked not to move the app, it's up to the parent application
       // to store this information and not hassle them again.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "electron-lets-move",
   "main": "src/index.js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "MIT",
   "repository": "tommoor/electron-lets-move",
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -30,10 +30,11 @@ function isInDownloadsFolder() {
   return exePath.startsWith(downloadsPath);
 }
 
-function preferredInstallLocation() {
-  if (fs.existsSync(userApplicationPath)) {
+function preferredInstallLocation(preferRoot) {
+  if (!preferRoot && fs.existsSync(userApplicationPath)) {
     return userApplicationPath;
   }
+
   return rootApplicationPath;
 }
 
@@ -54,12 +55,13 @@ function getDialogMessage(needsAuthorization) {
   return detail;
 }
 
-function moveToApplications(callback) {
+function moveToApplications(opts) {
   let resolve;
   let reject;
+  const callback = typeof(opts) =='function' ? opts : opts.callback;
   const bundlePath = getBundlePath();
   const fileName = path.basename(bundlePath);
-  const installLocation = path.join(preferredInstallLocation(), fileName);
+  const installLocation = path.join(preferredInstallLocation(opts.preferRoot), fileName);
 
   // We return a promise so that the parent application can await the result.
   // Also support an optional callback for those that prefer a callback style.

--- a/src/index.js
+++ b/src/index.js
@@ -58,10 +58,11 @@ function getDialogMessage(needsAuthorization) {
 function moveToApplications(opts) {
   let resolve;
   let reject;
-  const callback = typeof(opts) =='function' ? opts : opts.callback;
+  const callback = typeof(opts) == 'function' ? opts : opts.callback;
   const bundlePath = getBundlePath();
   const fileName = path.basename(bundlePath);
-  const installLocation = path.join(preferredInstallLocation(opts.preferRoot), fileName);
+  const installDirectory = preferredInstallLocation(opts.preferRoot);
+  const installLocation = path.join(installDirectory, fileName);
 
   // We return a promise so that the parent application can await the result.
   // Also support an optional callback for those that prefer a callback style.
@@ -89,7 +90,7 @@ function moveToApplications(opts) {
   }
 
   // Check if the install location needs administrator permissions
-  canWrite(installLocation, (err, isWritable) => {
+  canWrite(installDirectory, (err, isWritable) => {
     const needsAuthorization = !isWritable;
 
     // show dialog requesting to move


### PR DESCRIPTION
This adds in the ability to pass an options object to the function. The two supported are optional `callback` or `preferRoot`

Also fixed an issue where it was looking at the destination filepath (installDirectory + appname.app) instead of just installDirectory for write permissions.

Merge if you find useful.